### PR TITLE
Add `nameRootClasses` configuration option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Clean
         if: ${{ false }} # Skip, since it fails on Windows: https://youtrack.jetbrains.com/issue/KT-50545/
         run: .\gradlew.bat clean
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Clean
         run: ./gradlew clean
       - name: Publish to Maven

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Install ncurses5
         run: sudo apt-get install libncurses5
       - name: Clean
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Clean
         if: ${{ false }} # Skip, since it fails on Windows: https://youtrack.jetbrains.com/issue/KT-50545/
         run: .\gradlew.bat clean
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Clean
         run: ./gradlew clean
       - name: Test

--- a/api/knbt.api
+++ b/api/knbt.api
@@ -50,6 +50,7 @@ public final class net/benwoodworth/knbt/NbtBuilder : net/benwoodworth/knbt/NbtF
 	public final fun getCompressionLevel ()Ljava/lang/Integer;
 	public fun getEncodeDefaults ()Z
 	public fun getIgnoreUnknownKeys ()Z
+	public fun getNameRootClasses ()Z
 	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public final fun getVariant ()Lnet/benwoodworth/knbt/NbtVariant;
 	public fun setClassDiscriminator (Ljava/lang/String;)V
@@ -57,6 +58,7 @@ public final class net/benwoodworth/knbt/NbtBuilder : net/benwoodworth/knbt/NbtF
 	public final fun setCompressionLevel (Ljava/lang/Integer;)V
 	public fun setEncodeDefaults (Z)V
 	public fun setIgnoreUnknownKeys (Z)V
+	public fun setNameRootClasses (Z)V
 	public fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
 	public final fun setVariant (Lnet/benwoodworth/knbt/NbtVariant;)V
 }
@@ -232,6 +234,7 @@ public final class net/benwoodworth/knbt/NbtConfiguration : net/benwoodworth/knb
 	public final fun getCompressionLevel ()Ljava/lang/Integer;
 	public fun getEncodeDefaults ()Z
 	public fun getIgnoreUnknownKeys ()Z
+	public fun getNameRootClasses ()Z
 	public final fun getVariant ()Lnet/benwoodworth/knbt/NbtVariant;
 	public fun toString ()Ljava/lang/String;
 }
@@ -347,10 +350,12 @@ public abstract interface class net/benwoodworth/knbt/NbtFormatBuilder {
 	public abstract fun getClassDiscriminator ()Ljava/lang/String;
 	public abstract fun getEncodeDefaults ()Z
 	public abstract fun getIgnoreUnknownKeys ()Z
+	public abstract fun getNameRootClasses ()Z
 	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public abstract fun setClassDiscriminator (Ljava/lang/String;)V
 	public abstract fun setEncodeDefaults (Z)V
 	public abstract fun setIgnoreUnknownKeys (Z)V
+	public abstract fun setNameRootClasses (Z)V
 	public abstract fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
 }
 
@@ -358,6 +363,7 @@ public abstract interface class net/benwoodworth/knbt/NbtFormatConfiguration {
 	public abstract fun getClassDiscriminator ()Ljava/lang/String;
 	public abstract fun getEncodeDefaults ()Z
 	public abstract fun getIgnoreUnknownKeys ()Z
+	public abstract fun getNameRootClasses ()Z
 }
 
 public final class net/benwoodworth/knbt/NbtInt : net/benwoodworth/knbt/NbtTag {
@@ -738,12 +744,14 @@ public final class net/benwoodworth/knbt/StringifiedNbtBuilder : net/benwoodwort
 	public fun getClassDiscriminator ()Ljava/lang/String;
 	public fun getEncodeDefaults ()Z
 	public fun getIgnoreUnknownKeys ()Z
+	public fun getNameRootClasses ()Z
 	public final fun getPrettyPrint ()Z
 	public final fun getPrettyPrintIndent ()Ljava/lang/String;
 	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public fun setClassDiscriminator (Ljava/lang/String;)V
 	public fun setEncodeDefaults (Z)V
 	public fun setIgnoreUnknownKeys (Z)V
+	public fun setNameRootClasses (Z)V
 	public final fun setPrettyPrint (Z)V
 	public final fun setPrettyPrintIndent (Ljava/lang/String;)V
 	public fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
@@ -753,6 +761,7 @@ public final class net/benwoodworth/knbt/StringifiedNbtConfiguration : net/benwo
 	public fun getClassDiscriminator ()Ljava/lang/String;
 	public fun getEncodeDefaults ()Z
 	public fun getIgnoreUnknownKeys ()Z
+	public fun getNameRootClasses ()Z
 	public final fun getPrettyPrint ()Z
 	public final fun getPrettyPrintIndent ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;

--- a/src/commonMain/kotlin/Nbt.kt
+++ b/src/commonMain/kotlin/Nbt.kt
@@ -53,6 +53,7 @@ private object DefaultNbt : Nbt(
         encodeDefaults = false,
         ignoreUnknownKeys = false,
         classDiscriminator = "type",
+        nameRootClasses = true,
     ),
     serializersModule = EmptySerializersModule(),
 )
@@ -107,6 +108,8 @@ public class NbtBuilder internal constructor(nbt: Nbt) : NbtFormatBuilder {
 
     override var classDiscriminator: String = nbt.configuration.classDiscriminator
 
+    override var nameRootClasses: Boolean = nbt.configuration.nameRootClasses
+
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [Nbt] instance.
      */
@@ -131,7 +134,8 @@ public class NbtBuilder internal constructor(nbt: Nbt) : NbtFormatBuilder {
                 compressionLevel = compressionLevel,
                 encodeDefaults = encodeDefaults,
                 ignoreUnknownKeys = ignoreUnknownKeys,
-                classDiscriminator = classDiscriminator
+                classDiscriminator = classDiscriminator,
+                nameRootClasses = nameRootClasses
             ),
             serializersModule = serializersModule,
         )

--- a/src/commonMain/kotlin/NbtConfiguration.kt
+++ b/src/commonMain/kotlin/NbtConfiguration.kt
@@ -7,6 +7,7 @@ public class NbtConfiguration internal constructor(
     override val encodeDefaults: Boolean,
     override val ignoreUnknownKeys: Boolean,
     override val classDiscriminator: String,
+    override val nameRootClasses: Boolean,
 ) : NbtFormatConfiguration {
     override fun toString(): String =
         "NbtConfiguration(" +
@@ -16,5 +17,6 @@ public class NbtConfiguration internal constructor(
                 ", encodeDefaults=$encodeDefaults" +
                 ", ignoreUnknownKeys=$ignoreUnknownKeys" +
                 ", classDiscriminator='$classDiscriminator'" +
+                ", nameRootClasses=$nameRootClasses" +
                 ")"
 }

--- a/src/commonMain/kotlin/NbtFormatConfiguration.kt
+++ b/src/commonMain/kotlin/NbtFormatConfiguration.kt
@@ -4,4 +4,5 @@ public sealed interface NbtFormatConfiguration {
     public val encodeDefaults: Boolean
     public val ignoreUnknownKeys: Boolean
     public val classDiscriminator: String
+    public val nameRootClasses: Boolean
 }

--- a/src/commonMain/kotlin/StringifiedNbt.kt
+++ b/src/commonMain/kotlin/StringifiedNbt.kt
@@ -23,7 +23,8 @@ public sealed class StringifiedNbt(
             ignoreUnknownKeys = false,
             prettyPrint = false,
             prettyPrintIndent = "    ",
-            classDiscriminator = "type"
+            classDiscriminator = "type",
+            nameRootClasses = true
         ),
         serializersModule = EmptySerializersModule(),
     )
@@ -88,6 +89,8 @@ public class StringifiedNbtBuilder internal constructor(stringifiedNbt: Stringif
 
     override var classDiscriminator: String = stringifiedNbt.configuration.classDiscriminator
 
+    override var nameRootClasses: Boolean = stringifiedNbt.configuration.nameRootClasses
+
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [StringifiedNbt] instance.
      */
@@ -113,7 +116,8 @@ public class StringifiedNbtBuilder internal constructor(stringifiedNbt: Stringif
                 ignoreUnknownKeys = ignoreUnknownKeys,
                 prettyPrint = prettyPrint,
                 prettyPrintIndent = prettyPrintIndent,
-                classDiscriminator = classDiscriminator
+                classDiscriminator = classDiscriminator,
+                nameRootClasses = nameRootClasses
             ),
             serializersModule = serializersModule,
         )

--- a/src/commonMain/kotlin/StringifiedNbtConfiguration.kt
+++ b/src/commonMain/kotlin/StringifiedNbtConfiguration.kt
@@ -7,6 +7,7 @@ public class StringifiedNbtConfiguration internal constructor(
     @ExperimentalNbtApi
     public val prettyPrintIndent: String,
     override val classDiscriminator: String,
+    override val nameRootClasses: Boolean,
 ) : NbtFormatConfiguration {
     @OptIn(ExperimentalNbtApi::class)
     override fun toString(): String =
@@ -16,5 +17,6 @@ public class StringifiedNbtConfiguration internal constructor(
                 ", prettyPrint=$prettyPrint" +
                 ", prettyPrintIndent='$prettyPrintIndent'" +
                 ", classDiscriminator='$classDiscriminator'" +
+                ", nameRootClasses=$nameRootClasses" +
                 ")"
 }

--- a/src/commonTest/kotlin/NbtFormatConfigurationTest.kt
+++ b/src/commonTest/kotlin/NbtFormatConfigurationTest.kt
@@ -1,6 +1,5 @@
 package net.benwoodworth.knbt
 
-import com.benwoodworth.parameterize.parameter
 import com.benwoodworth.parameterize.parameterOf
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -98,5 +97,27 @@ class NbtFormatConfigurationTest {
         }
 
         assertEquals(classDiscriminatorValue, nbt.configuration.classDiscriminator)
+    }
+
+    @Test
+    fun name_root_classes_default_should_be_true() = parameterizeTest {
+        var actualDefault: Boolean? = null
+
+        parameterizedNbtFormat {
+            actualDefault = nameRootClasses
+        }
+
+        assertEquals(true, actualDefault)
+    }
+
+    @Test
+    fun name_root_classes_should_apply_when_built() = parameterizeTest {
+        val nameRootClassesValue by parameterOf(true, false)
+
+        val nbt = parameterizedNbtFormat {
+            nameRootClasses = nameRootClassesValue
+        }
+
+        assertEquals(nameRootClassesValue, nbt.configuration.nameRootClasses)
     }
 }

--- a/src/commonTest/kotlin/NestRootClassesTest.kt
+++ b/src/commonTest/kotlin/NestRootClassesTest.kt
@@ -1,0 +1,124 @@
+package net.benwoodworth.knbt
+
+import com.benwoodworth.parameterize.parameter
+import com.benwoodworth.parameterize.parameterOf
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class NestRootClassesTest {
+    private class TestCase<T>(
+        val serializer: KSerializer<T>,
+        val value: T,
+        val serializersModule: SerializersModule = EmptySerializersModule()
+    ) {
+        override fun toString(): String =
+            serializer.descriptor.serialName
+
+        fun encodeToNbtTag(nbt: NbtFormat): NbtTag =
+            nbt.encodeToNbtTag(serializer, value)
+
+        fun decodeFromNbtTag(nbt: NbtFormat, tag: NbtTag): T =
+            nbt.decodeFromNbtTag(serializer, tag)
+    }
+
+    @Serializable
+    private data class Class(val element: String)
+
+    private abstract class AbstractClass {
+        @Serializable
+        data class Impl(val element: String) : AbstractClass()
+    }
+
+    private interface Interface {
+        @Serializable
+        data class Impl(val element: String) : Interface
+    }
+
+    @Serializable
+    private sealed class SealedClass {
+        @Serializable
+        data class Impl(val element: String) : SealedClass()
+    }
+
+    @Serializable
+    private sealed interface SealedInterface {
+        @Serializable
+        data class Impl(val element: String) : SealedInterface
+    }
+
+    private val testCases = listOf(
+        TestCase(
+            Class.serializer(),
+            Class("value")
+        ),
+        TestCase(
+            PolymorphicSerializer(AbstractClass::class),
+            AbstractClass.Impl("value"),
+            SerializersModule {
+                polymorphic(AbstractClass::class, AbstractClass.Impl::class, AbstractClass.Impl.serializer())
+            }
+        ),
+        TestCase(
+            PolymorphicSerializer(Interface::class),
+            Interface.Impl("value"),
+            SerializersModule {
+                polymorphic(Interface::class, Interface.Impl::class, Interface.Impl.serializer())
+            }
+        ),
+        TestCase(
+            SealedClass.serializer(),
+            SealedClass.Impl("value")
+        ),
+        TestCase(
+            SealedInterface.serializer(),
+            SealedInterface.Impl("value")
+        )
+    )
+
+    @Test
+    fun class_encoded_with_nesting_be_class_without_nesting_wrapped_in_serial_name() = parameterizeTest {
+        val testCase by parameter(testCases)
+
+        val nbtWithoutNesting = parameterizedNbtFormat {
+            nameRootClasses = false
+            serializersModule = testCase.serializersModule
+        }
+
+        val nbtWithNesting = NbtFormat(nbtWithoutNesting) {
+            nameRootClasses = true
+        }
+
+        val tagWithoutNesting = testCase.encodeToNbtTag(nbtWithoutNesting)
+        val tagWithNesting = testCase.encodeToNbtTag(nbtWithNesting)
+
+        val expectedTagWithNesting = buildNbtCompound {
+            put(testCase.serializer.descriptor.serialName, tagWithoutNesting)
+        }
+
+        assertEquals(expectedTagWithNesting, tagWithNesting)
+    }
+
+    @Test
+    fun should_correctly_serialize_class_with_name_root_classes_configured() = parameterizeTest {
+        val testCase by parameter(testCases)
+
+        val nameRootClasses by parameterOf(true, false)
+
+        val nbt = parameterizedNbtFormat {
+            this.nameRootClasses = nameRootClasses
+            serializersModule = testCase.serializersModule
+        }
+
+        val encoded = testCase.encodeToNbtTag(nbt)
+        val decoded = testCase.decodeFromNbtTag(nbt, encoded)
+
+        assertEquals(testCase.value, decoded, "Decoded tag")
+    }
+}

--- a/src/commonTest/kotlin/Util.kt
+++ b/src/commonTest/kotlin/Util.kt
@@ -123,3 +123,9 @@ fun ParameterizeScope.parameterizedNbtFormat(
 
     return NbtFormat(builderAction)
 }
+
+fun NbtFormat(from: NbtFormat, builderAction: NbtFormatBuilder.() -> Unit): NbtFormat =
+    when (from) {
+        is Nbt -> Nbt(from, builderAction)
+        is StringifiedNbt -> StringifiedNbt(from, builderAction)
+    }


### PR DESCRIPTION
The default root class nesting behavior will eventually be removed due to it being problematic for a number of reasons. (See #29)

But until then, this provides a way to opt out of that behavior entirely.

See discussion with @Ayfri [in the Kotlin Slack](https://kotlinlang.slack.com/archives/C046BGVBJEP/p1711982124447009)